### PR TITLE
chore(deps): remove unnecessary react-dom and js-yaml dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "ink": "^6.5.1",
         "ink-testing-library": "^4.0.0",
         "jest": "^29.7.0",
-        "js-yaml": "^4.1.0",
         "license-checker": "^25.0.1",
         "prettier": "^3.2.5",
         "react": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "ink": "^6.5.1",
     "ink-testing-library": "^4.0.0",
     "jest": "^29.7.0",
-    "js-yaml": "^4.1.0",
     "license-checker": "^25.0.1",
     "prettier": "^3.2.5",
     "react": "^19.2.3",


### PR DESCRIPTION
## Summary
- Remove `react-dom` and `@types/react-dom` from devDependencies
  - ink uses its own terminal renderer, not react-dom (which is for browser DOM)
- Remove `js-yaml` dependency by rewriting validation scripts to use regex-based parsing
  - `validate-sha-pinning.js`: Uses regex to extract `uses:` lines
  - `validate-permissions.js`: Uses indent-based parsing for permissions blocks
- Reduces dependency tree and attack surface

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 359 tests pass (`npm test`)
- [x] `validate-sha-pinning.js` works correctly
- [x] `validate-permissions.js` works correctly