### PR TITLE
fix(ci): remove duplicate create-release job from publish-npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -165,34 +165,3 @@ jobs:
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  create-release:
-    runs-on: ubuntu-latest
-    needs: publish
-    permissions:
-      contents: write
-    
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-
-      - name: Create GitHub Release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref_name }}
-          body: |
-            🎉 New release published to npm!
-            
-            ### Installation
-            ```bash
-            npm install @pppp606/ink-chart@${{ github.ref_name }}
-            ```
-            
-            ### Demo
-            ```bash
-            npx ink-chart-demo
-            ```
-          draft: false
-          prerelease: false


### PR DESCRIPTION
## Summary
- Remove the `create-release` job from `publish-npm.yml`
- Release Drafter already creates and manages GitHub Releases, so this job was attempting to create a release with the same tag, causing an `already_exists` error

## Background
When publishing a draft release via `gh release edit --draft=false`, a tag is created, which triggers `publish-npm.yml`. The `create-release` job then tries to create a release with the same tag that already exists, resulting in failure.

## Impact
- No impact on npm publishing (`publish` job) — `create-release` is a downstream job
- The `create-release` in `publish-github.yml` for Canary Releases is unaffected (different use case)

## Test plan
- [ ] `node scripts/validate-sha-pinning.js` passes
- [ ] CI passes