### PR TITLE
Improve URL validation for OIDC endpoints using hostname parsing

### DIFF
--- a/__tests__/oidc-publishing.test.ts
+++ b/__tests__/oidc-publishing.test.ts
@@ -363,7 +363,19 @@ function validatePublicationReadiness(): {
 function validateOidcTokenRequest(): void {
   const url = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
 
-  if (!url || !url.includes('actions.githubusercontent.com')) {
+  if (!url) {
+    throw new Error('OIDC token request failed: Invalid token request URL');
+  }
+
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    throw new Error('OIDC token request failed: Invalid token request URL');
+  }
+
+  if (hostname !== 'actions.githubusercontent.com' &&
+      !hostname.endsWith('.actions.githubusercontent.com')) {
     throw new Error('OIDC token request failed: Invalid token request URL');
   }
 }

--- a/__tests__/oidc-publishing.test.ts
+++ b/__tests__/oidc-publishing.test.ts
@@ -329,7 +329,9 @@ async function validateRegistryConnectivity(registryUrl: string): Promise<boolea
   try {
     // In a real implementation, this would make an HTTP request
     // For testing, we'll simulate a successful check
-    return registryUrl.includes('registry.npmjs.org');
+    const hostname = new URL(registryUrl).hostname;
+    return hostname === 'registry.npmjs.org' ||
+      hostname.endsWith('.registry.npmjs.org');
   } catch {
     return false;
   }

--- a/__tests__/oidc-validation.test.ts
+++ b/__tests__/oidc-validation.test.ts
@@ -334,8 +334,9 @@ function validateOidcEnvironment(): boolean {
   // Validate URL format - should be GitHub Actions OIDC endpoint
   try {
     const parsedUrl = new URL(url);
-    if (!parsedUrl.hostname.includes('actions.githubusercontent.com') &&
-        !parsedUrl.hostname.includes('vstoken.actions.githubusercontent.com')) {
+    const hostname = parsedUrl.hostname;
+    if (hostname !== 'actions.githubusercontent.com' &&
+        !hostname.endsWith('.actions.githubusercontent.com')) {
       return false;
     }
   } catch {


### PR DESCRIPTION
## Summary
This PR improves the URL validation logic for OIDC token requests and registry connectivity checks by using proper URL parsing instead of simple string matching. This makes the validation more robust and prevents false positives from substring matches.

## Key Changes
- **Registry connectivity validation**: Changed from `includes()` substring matching to proper hostname parsing that checks for exact matches or subdomain matches using `endsWith()`
- **OIDC token request validation**: Refactored to parse the URL and validate the hostname separately, with explicit error handling for malformed URLs
- **OIDC environment validation**: Updated hostname validation to use `endsWith()` instead of `includes()` for more precise subdomain matching, removing the hardcoded `vstoken.actions.githubusercontent.com` check in favor of a generic subdomain pattern

## Implementation Details
- All URL validation now uses the `URL` constructor for proper parsing, with try-catch blocks to handle invalid URLs gracefully
- Hostname validation uses exact equality checks (`===`) for the primary domain and `endsWith()` for subdomain matching, which is more secure and accurate than substring matching
- Error messages are consistent and descriptive across both test files