### PR TITLE
fix(deps): bump fast-uri to 3.1.2 to resolve Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3979,9 +3979,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Bump transitive dependency `fast-uri` from `3.1.0` to `3.1.2` (in `package-lock.json` only) to resolve two high-severity Dependabot alerts.
- Pulled in via `ajv` from devDependencies (`@secretlint/config-loader`, `table`).

## Vulnerabilities fixed
- [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — path traversal via percent-encoded dot segments (CWE-22, CVSS 7.5)
- [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — host confusion via percent-encoded authority delimiters (CWE-436, CVSS 7.5)

## Test plan
- [x] `npm audit` → 0 vulnerabilities
- [x] `npm test` → 419/419 passing
- [x] `npm run build` succeeds
- [x] `npm run lint` (no errors)

https://claude.ai/code/session_01ErKEHjp49M1K9iNctByba9

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErKEHjp49M1K9iNctByba9)_