### PR TITLE
chore(release): bump version to 0.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pppp606/ink-chart",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pppp606/ink-chart",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "bin": {
         "ink-chart-demo": "bin/demo.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pppp606/ink-chart",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Small visualization components for ink CLI framework",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump `package.json` version from `0.2.5` to `0.2.6` to prepare for release.
- Includes the `fast-uri` security fix merged in #108.

## Test plan
- [x] `npm test` → 419/419 passing
- [x] `npm audit` → 0 vulnerabilities

After merge, tag `v0.2.6` will be pushed to trigger `publish-npm.yml` and publish to npm with provenance.

https://claude.ai/code/session_01ErKEHjp49M1K9iNctByba9

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErKEHjp49M1K9iNctByba9)_