### PR TITLE
fix(security): bump lodash & fast-uri to patched versions (lockfile)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4510,9 +4510,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -6800,9 +6800,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
## What

Refresh `package-lock.json` to pull patched versions of two transitive dependencies. **No `package.json` change** — `npm update` resolved them within the parents' existing semver ranges.

- `lodash` `4.17.23` → `4.18.1`
- `fast-uri` `3.1.0` → `3.1.2`

## Why

`npm audit --audit-level high` reported **2 high-severity advisories**, both in **secretlint's deep transitive dependencies**:

| pkg | path | advisories |
|---|---|---|
| lodash | secretlint → @secretlint/formatter → @textlint/linter-formatter | [GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc) (code injection via `_.template`), [GHSA-f23m-r3pf-42rh](https://github.com/advisories/GHSA-f23m-r3pf-42rh) (prototype pollution in `_.unset`/`_.omit`) |
| fast-uri | secretlint → ajv | [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) (path traversal), [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) (host confusion) |

The patched versions were **already within the parents' declared ranges** (`ajv` requires `fast-uri ^3.0.1`; `@textlint/linter-formatter` requires `lodash ^4.17.23`) — the lockfile had simply frozen older resolutions. So a plain `npm update` of these two packages fixes both, no `overrides` needed.

### Why lockfile-only instead of `overrides`

`overrides` is for when a parent's range *won't* allow the patched version. Here the ranges already allow it, so refreshing the lockfile is the idiomatic fix (same thing `npm audit fix` does internally) and leaves **no `overrides` block to maintain/remove later**. No Dependabot PR currently covers these advisories (the open security-updates group #117 predates them).

## Verification

- `npm audit --audit-level high` → **clean** (exit 0; only 2 unrelated moderate advisories remain, below our `config.audit-level: high` gate)
- `npm run lint:secrets` (secretlint) ✅
- `npm run typecheck` ✅
- security-scanning audit test ✅

## Diff
`package-lock.json` only — lodash & fast-uri versions (6 +/- 6).