### PR TITLE
chore: remove leftover license-check script and its tests

### DIFF
--- a/__tests__/package-security.test.ts
+++ b/__tests__/package-security.test.ts
@@ -122,10 +122,6 @@ describe('Package Configuration Security', () => {
       expect(packageJson.scripts['lint:secrets']).toBeDefined();
     });
 
-    test('should have license checking script', () => {
-      expect(packageJson.scripts['license-check']).toBeDefined();
-    });
-
     test('should have validation scripts', () => {
       expect(packageJson.scripts['validate:sha-pinning']).toBeDefined();
       expect(packageJson.scripts['validate:permissions']).toBeDefined();

--- a/__tests__/security-scanning.test.ts
+++ b/__tests__/security-scanning.test.ts
@@ -87,13 +87,6 @@ describe('Security Scanning', () => {
       }
     });
 
-    it('should validate dependency licenses are compatible', () => {
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-
-      // Test that we have license checking capability
-      expect(packageJson.scripts).toHaveProperty('license-check');
-    });
-
     it('should have automated security update configuration', () => {
       const dependabotPath = path.join(process.cwd(), '.github/dependabot.yml');
       const renovatePath = path.join(process.cwd(), 'renovate.json');

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "demo": "npm run build && node bin/demo.js",
     "audit": "npm audit --audit-level high",
     "audit:fix": "npm audit fix --dry-run",
-    "license-check": "npx license-checker --summary",
     "validate:sha-pinning": "node scripts/validate-sha-pinning.js",
     "validate:permissions": "node scripts/validate-permissions.js",
     "prepublishOnly": "npm run build"


### PR DESCRIPTION
## What

Remove the vestigial `license-check` npm script and the two tests asserting it exists.

## Why

The `license-checker` devDependency was removed in #95 (`ed3df6a`), but the script that invokes it was left behind:

```json
"license-check": "npx license-checker --summary"
```

So `package.json` still has a script referencing a dependency that is no longer declared. This PR removes:

- the `license-check` script (`package.json`)
- `should have license checking script` (`__tests__/package-security.test.ts`)
- `should validate dependency licenses are compatible` (`__tests__/security-scanning.test.ts`)

Ad-hoc license audits remain available on demand without a devDependency:

```
npx license-checker --summary
```

## Verification

- `npx jest __tests__/security-scanning.test.ts __tests__/package-security.test.ts` → **47 passed**
- No remaining `license-check` / `license-checker` references in the repo

Built directly off current `main` (v0.2.6).