### PR TITLE
fix(ci): restore npm upgrade step for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,6 +23,13 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      # OIDC trusted publishing requires npm >= 11.5.1; Node 20 ships npm 10.x.
+      # This step was removed in 9c94873 and must stay to keep publishing working.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+
       - run: npm ci
 
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Problem

The v0.2.6 publish to npm **failed with `E404 ... '@pppp606/ink-chart@0.2.6' is not in this registry`**, even though the npm Trusted Publisher is correctly configured (pppp606/ink-chart → publish-npm.yml).

## Root cause

`publish-npm.yml` uses **npm OIDC trusted publishing** (`npm publish --provenance`, `id-token: write`, no `NPM_TOKEN`). That requires **npm ≥ 11.5.1**, but `actions/setup-node` with `node-version: '20'` ships **npm 10.x**.

The required `npm install -g npm@latest` step was added in `2d7ae74` ("upgrade npm to latest for OIDC trusted publishing support") and then **accidentally removed in `9c94873`** ("simplify release workflow").

With npm 10.x the provenance statement is still signed (OIDC token exchange works), but the actual registry PUT is unauthenticated → `E404`. This exactly matches the observed failure.

## Fix

Restore the npm upgrade step between `setup-node` and `npm ci`:

```yaml
- name: Upgrade npm for OIDC trusted publishing
  run: |
    npm install -g npm@latest
    npm --version
```

## After merge

The `v0.2.6` tag (and GitHub release) already exist but point to a commit without this fix. Once merged, the tag will be re-pointed to the fixed commit and re-pushed to re-trigger publishing — no version bump needed (0.2.6 was never published).