### PR TITLE
chore(release): bump version to 0.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pppp606/ink-chart",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pppp606/ink-chart",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "MIT",
       "bin": {
         "ink-chart-demo": "bin/demo.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pppp606/ink-chart",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Small visualization components for ink CLI framework",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
v0.2.7 リリースのためのバージョンバンプです。

## Changes since v0.2.6
- #128 fix(deps): Dependabot アラート3件（js-yaml, @babel/core）と npm audit 検出の2件（brace-expansion, ws）を解消

マージ後、`v0.2.7` タグを push して npm へ OIDC trusted publishing でリリースします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)