### PR TITLE
fix(ci): pin npm to v11 in publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -25,9 +25,10 @@ jobs:
 
       # OIDC trusted publishing requires npm >= 11.5.1; Node 20 ships npm 10.x.
       # This step was removed in 9c94873 and must stay to keep publishing working.
+      # Pinned to npm@11: npm@12 requires Node >= 22 and breaks on this runner.
       - name: Upgrade npm for OIDC trusted publishing
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11
           npm --version
 
       - run: npm ci


### PR DESCRIPTION
## Summary
v0.2.7 の publish ワークフローが `npm install -g npm@latest` で **EBADENGINE** 失敗しました。npm@latest が 12.x になり Node >= 22 を要求するためです（ランナーは Node 20）。

OIDC trusted publishing に必要な npm >= 11.5.1 を満たしつつ Node 20 で動く **npm@11 にピン留め**します。

マージ後、`v0.2.7` タグをこの修正コミットに付け替えて再 push し、npm へ公開します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)