### PR TITLE
fix(security): resolve npm audit highs, add min-release-age & ignore-scripts guards

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -33,4 +33,8 @@ jobs:
 
       - run: npm ci
 
+      # .npmrc sets ignore-scripts=true, which also skips prepublishOnly,
+      # so the build must run explicitly before publishing.
+      - run: npm run build
+
       - run: npm publish --provenance --access public

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,9 @@
+# Supply-chain guard: never install versions published within the last 7 days
+# (requires npm >= 11; older npm ignores this key).
+min-release-age=7
+
+# Supply-chain guard: never run dependency lifecycle scripts (preinstall etc.).
+# No package in this tree needs them (checked 2026-08-04; fsevents ships a
+# prebuilt binary). NOTE: this also skips our own prepublishOnly hook, so the
+# publish workflow must run `npm run build` explicitly before `npm publish`.
+ignore-scripts=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -650,9 +650,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2617,16 +2617,16 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/brace-expansion/node_modules/balanced-match": {
@@ -3663,9 +3663,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3740,9 +3740,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3979,9 +3979,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -4317,9 +4317,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8126,9 +8126,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Security response prompted by the 2026-08-04 keyv supply chain compromise (Mini Shai-Hulud variant) — see the [Wiz Research incident report](https://www.wiz.io/blog/keyv-and-cacheable-npm-supply-chain-attack) and [Microsoft Threat Intelligence's confirmation of affected packages](https://x.com/MsftSecIntel/status/2084642457048752134). Three changes:

1. Add `min-release-age=7` to `.npmrc` (never install versions published within the last 7 days)
2. Add `ignore-scripts=true` to `.npmrc` (never run dependency lifecycle scripts)
3. Fix the outstanding npm audit high findings (Dependabot alerts #38 / #39 / #40) plus newer advisories — brace-expansion / fast-uri **applied 2026-08-07 under the policy, no overrides**; one remaining (js-yaml, alert #41) lands 2026-08-08 (see below)

Note: this repo is **not affected** by the keyv compromise itself — the lockfile pins `keyv@4.5.4` / `file-entry-cache@8.0.0` (the compromised 6.0.0 / 11.1.6 are unreachable from the semver ranges), and no other compromised package is in the tree.

## 1. `min-release-age=7`

npm ≥ 11 will refuse to resolve any version published within the last 7 days (npm 10 ignores the key harmlessly). A time-delay defense against freshly-compromised releases like `keyv@6.0.0`.

## 2. `ignore-scripts=true`

Dependency preinstall / install / postinstall hooks are never executed — the exact execution vector of the keyv malware.

- Scanned the full tree and confirmed **zero** packages need install hooks (fsevents ships a prebuilt binary; every other lifecycle script is `prepare`, which never runs for registry dependencies)
- Side effect handled: `ignore-scripts` also skips this package's own `prepublishOnly` (build) hook, so `publish-npm.yml` now runs `npm run build` explicitly before `npm publish`. Verified via `npm pack --dry-run` that the tarball contains the complete dist/ (60 files)

## 3. Vulnerability patches (all transitive devDependencies)

Rather than overriding the 7-day policy on day one, this PR **waits** for each patched version to clear the window and then applies it with a plain `npx npm@11 audit fix` — resolved with `min-release-age=7` active, no overrides.

**Applied 2026-08-07:**

| Package | Before | After | Advisories |
|---|---|---|---|
| brace-expansion (nested ×6) | 1.1.13 | 1.1.18 | GHSA-3jxr-9vmj-r5cp, GHSA-rgw5-rvv9-x895 |
| brace-expansion (top-level) | 5.0.7 | 5.0.9 | GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 |
| fast-uri | 3.1.2 | 3.1.5 | GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx, GHSA-7p8r-x3mc-p8w7 |

Resolves Dependabot alerts #38 / #39 / #40.

**Pending until 2026-08-08 (draft until then):**

| Package | Current | Target | Advisory | Clears the 7-day window |
|---|---|---|---|---|
| js-yaml (top-level) | 4.3.0 | 4.3.1 | GHSA-5p4m-2wfm-xmqj (!!omap DoS, alert #41) | Aug 7 17:39 UTC |
| js-yaml (nested) | 3.15.0 | 3.15.1 | GHSA-5p4m-2wfm-xmqj | Aug 7 17:48 UTC |

This advisory was published Aug 5, after this PR was opened. When `npm audit fix` ran on Aug 7, npm 11 correctly **retained the vulnerable version and exited non-zero** because the fixes were still inside the 7-day window — the policy working exactly as documented. The follow-up commit lands Aug 8, after which `npm audit --audit-level high` reports 0 and the PR will be marked ready.

Until then the CI `npm audit` step on this PR stays red (expected; it is red on main and every Dependabot PR for the same reason). The risk of waiting is low: all findings are DoS / host-confusion issues inside dev-only lint/test tooling.

## Verification (guards commit)

- Removed `node_modules` entirely, then clean `npm ci` with scripts disabled → typecheck / eslint / secretlint / 412 unit tests / 79 e2e tests / build / `validate:sha-pinning` / `validate:permissions` all pass

## After merge

- Dependabot alerts #38 / #39 / #40 / #41 will be resolved (once the Aug 8 commit lands)
- The stale Dependabot PRs #132 (does not fix these alerts) and #107 (brace-expansion 1.1.14, insufficient) should auto-close; closing them manually is fine if they don't

🤖 Generated with [Claude Code](https://claude.com/claude-code)
