### PR TITLE
chore(release): bump version to 0.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pppp606/ink-chart",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pppp606/ink-chart",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "MIT",
       "bin": {
         "ink-chart-demo": "bin/demo.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pppp606/ink-chart",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Small visualization components for ink CLI framework",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Release v0.2.8.

### Changes since v0.2.7
- #135: resolved all 6 Dependabot security alerts (js-yaml, fast-uri, brace-expansion — lockfile-only)
- #136: dev-dependency major bumps (typescript 6, jest 30, ink 7, eslint-plugin-react-hooks 7, secretlint 13)
- #130: pin npm@11 in publish workflow

No changes to published runtime code or peerDependencies (`ink >=6`, `react >=19`).

After merge: tag `v0.2.8` on main HEAD to trigger the OIDC npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)